### PR TITLE
fix(core): add branded types and encoder validation for input safety

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,6 +1,6 @@
 # @grounds/core
 
-Last verified: 2026-01-03
+Last verified: 2026-01-11
 
 ## Purpose
 
@@ -10,19 +10,21 @@ Low-level Relish wire format implementation. Provides type-safe value constructi
 
 - **Exposes**:
   - `TypeCode` - Constant object mapping type names to byte codes (0x00-0x13)
-  - `RelishValue` - Discriminated union of all Relish value types
+  - `RelishValue` - Discriminated union of all Relish value types (branded with internal symbol)
   - Value constructors: `Null`, `Bool`, `U8`...`Timestamp` (19 functions + 1 singleton)
   - `encode(value: RelishValue) -> Result<Uint8Array, EncodeError>` - Encode a value to bytes
   - `Encoder` class - Reusable encoder with pre-allocated buffer for performance
   - `decode(bytes: Uint8Array) -> Result<DecodedValue, DecodeError>` - Decode bytes to raw JS values
   - `Decoder` class - Cursor-based binary decoder with validation
-  - `EncodeError` - Error type with factory methods: `unsortedFields()`, `invalidFieldId()`, `invalidTypeCode()`, `unsupportedType()`, `unknownVariant()`
+  - `EncodeError` - Error type with factory methods: `unsortedFields()`, `invalidFieldId()`, `invalidTypeCode()`, `unsupportedType()`, `unknownVariant()`, `integerOutOfRange()`, `notAnInteger()`
   - `DecodeError` - Error type with `code` property and factory methods: `unexpectedEnd()`, `unknownTypeCode()`, `invalidTypeCode()`, `unsortedFields()`, `duplicateMapKey()`, `invalidUtf8()`, `enumLengthMismatch()`, `invalidFieldId()`, `invalidVariantId()`, `missingRequiredField()`, `unknownVariantId()`, `unsupportedType()`, `truncatedStream()`
   - `DecodeErrorCode` - Discriminated union type for error classification: "UNEXPECTED_EOF" | "INVALID_TYPE_CODE" | "INVALID_LENGTH" | "INVALID_UTF8" | "INTEGER_OVERFLOW" | "TRUNCATED_STREAM" | "UNSORTED_FIELDS" | "DUPLICATE_MAP_KEY" | "ENUM_LENGTH_MISMATCH" | "INVALID_FIELD_ID" | "INVALID_VARIANT_ID" | "MISSING_REQUIRED_FIELD" | "UNKNOWN_VARIANT_ID" | "UNSUPPORTED_TYPE"
   - `DecodedValue` - Union type for decoder output (raw JS values: number | bigint | boolean | null | string | DateTime | ReadonlyArray | ReadonlyMap | object)
 - **Guarantees**:
-  - All RelishValue types are readonly/immutable
+  - All RelishValue types are readonly/immutable and branded (cannot be constructed with object literals)
+  - RelishValue must be created through value constructor functions (U8(), String_(), etc.)
   - Integer value constructors (U8-U128, I8-I128) validate range at runtime, throw `Error` on invalid input
+  - Encoder validates integer values (defense in depth), returns `EncodeError` for invalid values
   - Array/Map constructors validate element types at runtime
   - 64-bit and 128-bit integers use BigInt
   - Timestamps use BigInt (Unix seconds) in encoding; Luxon DateTime in decoding
@@ -32,6 +34,7 @@ Low-level Relish wire format implementation. Provides type-safe value constructi
   - Map keys validated for uniqueness
   - Enum length validated for correctness
 - **Expects**:
+  - Callers use value constructor functions to create RelishValue (not object literals)
   - Callers handle thrown `Error` from value constructors when passing invalid input (programmer error)
   - Decoder callers provide complete, valid binary data
   - BigInt for u64/u128/i64/i128/timestamp values in RelishValue
@@ -46,6 +49,8 @@ Low-level Relish wire format implementation. Provides type-safe value constructi
 ## Key Decisions
 
 - Discriminated union over classes: Enables exhaustive pattern matching, smaller bundle
+- Branded types via `RELISH_BRAND` symbol: Prevents object literal construction, enforces use of constructor functions
+- Defense-in-depth validation: Encoder re-validates integers even with branded types (catches bypasses at runtime)
 - Runtime validation in Array_/Map_: Catches type mismatches early despite TypeScript erasure
 - Separate DecodedValue type: Decoder returns raw JS values, not wrapped RelishValue
 - Encoder class with reusable buffer: Avoids allocation overhead for repeated encoding
@@ -58,7 +63,9 @@ Low-level Relish wire format implementation. Provides type-safe value constructi
 ## Invariants
 
 - TypeCode values are 0x00-0x13; bit 7 is always 0
-- All RelishValue objects have readonly `type` discriminator
+- All RelishValue objects have readonly `type` discriminator and `RELISH_BRAND` symbol property
+- RelishValue cannot be created with object literals (TypeScript compiler error due to branded symbol)
+- Integer values are always within type-specific bounds (enforced at construction and encoding)
 - Struct fields keyed by numeric field ID, not string names
 - Map entries use native JavaScript Map (ordered insertion)
 - Field IDs and variant IDs must have bit 7 clear (valid range 0-127)
@@ -68,18 +75,22 @@ Low-level Relish wire format implementation. Provides type-safe value constructi
 ## Key Files
 
 - `index.ts` - Public exports (re-exports from other modules)
-- `types.ts` - TypeCode constants and RelishValue/DecodedValue type definitions
-- `values.ts` - Value constructor functions
+- `types.ts` - TypeCode constants, RelishValue/DecodedValue type definitions, RELISH_BRAND symbol
+- `values.ts` - Value constructor functions (with validation)
 - `errors.ts` - EncodeError and DecodeError classes with factory methods
-- `encoder.ts` - Encoder class and encode() function
+- `encoder.ts` - Encoder class and encode() function (with defense-in-depth validation)
 - `decoder.ts` - Decoder class and decode() function
 - `encoding-helpers.ts` - Tagged varint encoding, type code mapping
+- `integer-bounds.ts` - Internal: integer range constants and validation functions (shared by values.ts and encoder.ts)
 
 ## Gotchas
 
 - `String_`, `Array_`, `Map_` named with underscore to avoid shadowing globals
+- RelishValue cannot be created with `{ type: "u8", value: 42 }` - use `U8(42)` constructor
 - Composite types in arrays/maps hold RelishValue, primitives hold raw JS values
 - Encoder.encode() resets position; reuse same Encoder instance for performance
+- Encoder validates integers even if value constructors are bypassed (defense in depth)
 - Array/Map elements encoded without type tag (type in container header)
 - Decoder validates all constraints (field order, map keys, enum length, bit 7 rules)
 - DateTime decoding may lose precision for extremely large Unix seconds values
+- `RELISH_BRAND` symbol is internal and not exported (prevents external type manipulation)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -35,6 +35,18 @@ export class EncodeError extends Error {
   static unknownVariant(variantName: string): EncodeError {
     return new EncodeError(`unknown enum variant: ${variantName}`);
   }
+
+  static integerOutOfRange(typeName: string, value: number | bigint, min: number | bigint, max: number | bigint): EncodeError {
+    return new EncodeError(
+      `${typeName} value ${value} is out of range (${min} to ${max})`
+    );
+  }
+
+  static notAnInteger(typeName: string, value: number): EncodeError {
+    return new EncodeError(
+      `${typeName} value must be an integer, got ${value}`
+    );
+  }
 }
 
 export type DecodeErrorCode =

--- a/packages/core/src/integer-bounds.ts
+++ b/packages/core/src/integer-bounds.ts
@@ -1,0 +1,103 @@
+// pattern: Functional Core
+
+/**
+ * Integer range constants and validation functions.
+ * Used by both value constructors (values.ts) and encoder validation (encoder.ts).
+ * @internal
+ */
+
+// Unsigned integer maximums
+export const U8_MAX = 255;
+export const U16_MAX = 65535;
+export const U32_MAX = 4294967295;
+export const U64_MAX = 18446744073709551615n;
+export const U128_MAX = 340282366920938463463374607431768211455n;
+
+// Signed integer ranges
+export const I8_MIN = -128;
+export const I8_MAX = 127;
+export const I16_MIN = -32768;
+export const I16_MAX = 32767;
+export const I32_MIN = -2147483648;
+export const I32_MAX = 2147483647;
+export const I64_MIN = -9223372036854775808n;
+export const I64_MAX = 9223372036854775807n;
+export const I128_MIN = -170141183460469231731687303715884105728n;
+export const I128_MAX = 170141183460469231731687303715884105727n;
+
+/**
+ * Validation error result for integer checks.
+ * Returns null if valid, or an error object with details.
+ */
+export type IntegerValidationError =
+  | { readonly kind: "not_integer"; readonly value: number }
+  | {
+      readonly kind: "out_of_range";
+      readonly value: number | bigint;
+      readonly min: number | bigint;
+      readonly max: number | bigint;
+    };
+
+/**
+ * Validate an unsigned number (u8, u16, u32) is an integer within range.
+ * @returns null if valid, or error details if invalid
+ */
+export function validateUnsignedNumber(
+  value: number,
+  max: number
+): IntegerValidationError | null {
+  if (!Number.isInteger(value)) {
+    return { kind: "not_integer", value };
+  }
+  if (value < 0 || value > max) {
+    return { kind: "out_of_range", value, min: 0, max };
+  }
+  return null;
+}
+
+/**
+ * Validate a signed number (i8, i16, i32) is an integer within range.
+ * @returns null if valid, or error details if invalid
+ */
+export function validateSignedNumber(
+  value: number,
+  min: number,
+  max: number
+): IntegerValidationError | null {
+  if (!Number.isInteger(value)) {
+    return { kind: "not_integer", value };
+  }
+  if (value < min || value > max) {
+    return { kind: "out_of_range", value, min, max };
+  }
+  return null;
+}
+
+/**
+ * Validate an unsigned bigint (u64, u128) is within range.
+ * @returns null if valid, or error details if invalid
+ */
+export function validateUnsignedBigInt(
+  value: bigint,
+  max: bigint
+): IntegerValidationError | null {
+  if (value < 0n || value > max) {
+    return { kind: "out_of_range", value, min: 0n, max };
+  }
+  return null;
+}
+
+/**
+ * Validate a signed bigint (i64, i128) is within range.
+ * @returns null if valid, or error details if invalid
+ */
+export function validateSignedBigInt(
+  value: bigint,
+  min: bigint,
+  max: bigint
+): IntegerValidationError | null {
+  if (value < min || value > max) {
+    return { kind: "out_of_range", value, min, max };
+  }
+  return null;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,14 @@
 import { DateTime } from "luxon";
 
 /**
+ * Unique symbol used to brand RelishValue types.
+ * This prevents direct object literal construction - values must be
+ * created through the value constructor functions (U8, U32, etc.).
+ * @internal
+ */
+export const RELISH_BRAND: unique symbol = Symbol("RelishValue");
+
+/**
  * Relish type codes as defined in the specification.
  * Each type has a unique 1-byte identifier (0x00-0x13).
  * Bit 7 is reserved and must not be set.
@@ -73,75 +81,90 @@ export type RelishValue =
   | RelishTimestamp;
 
 export type RelishNull = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "null";
 };
 
 export type RelishBool = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "bool";
   readonly value: boolean;
 };
 
 export type RelishU8 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "u8";
   readonly value: number;
 };
 
 export type RelishU16 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "u16";
   readonly value: number;
 };
 
 export type RelishU32 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "u32";
   readonly value: number;
 };
 
 export type RelishU64 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "u64";
   readonly value: bigint;
 };
 
 export type RelishU128 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "u128";
   readonly value: bigint;
 };
 
 export type RelishI8 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "i8";
   readonly value: number;
 };
 
 export type RelishI16 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "i16";
   readonly value: number;
 };
 
 export type RelishI32 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "i32";
   readonly value: number;
 };
 
 export type RelishI64 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "i64";
   readonly value: bigint;
 };
 
 export type RelishI128 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "i128";
   readonly value: bigint;
 };
 
 export type RelishF32 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "f32";
   readonly value: number;
 };
 
 export type RelishF64 = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "f64";
   readonly value: number;
 };
 
 export type RelishString = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "string";
   readonly value: string;
 };
@@ -201,6 +224,7 @@ export type TypeCodeToJsType<T extends TypeCode> =
  * For composite element types, elements are RelishValue.
  */
 export type RelishArray<T extends TypeCode = TypeCode> = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "array";
   readonly elementType: T;
   readonly elements: ReadonlyArray<TypeCodeToJsType<T>>;
@@ -212,6 +236,7 @@ export type RelishArray<T extends TypeCode = TypeCode> = {
  * For composite key/value types, entries hold RelishValue.
  */
 export type RelishMap<K extends TypeCode = TypeCode, V extends TypeCode = TypeCode> = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "map";
   readonly keyType: K;
   readonly valueType: V;
@@ -249,17 +274,20 @@ export type DecodedValue =
 export { DateTime } from "luxon";
 
 export type RelishStruct = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "struct";
   readonly fields: ReadonlyMap<number, RelishValue>;
 };
 
 export type RelishEnum = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "enum";
   readonly variantId: number;
   readonly value: RelishValue;
 };
 
 export type RelishTimestamp = {
+  readonly [RELISH_BRAND]: true;
   readonly type: "timestamp";
   readonly unixSeconds: bigint;
 };

--- a/packages/core/src/values.ts
+++ b/packages/core/src/values.ts
@@ -24,145 +24,184 @@ import type {
   TypeCodeToJsType,
   MapInput,
 } from "./types.js";
-import { TypeCode } from "./types.js";
+import { TypeCode, RELISH_BRAND } from "./types.js";
+import {
+  U8_MAX,
+  U16_MAX,
+  U32_MAX,
+  U64_MAX,
+  U128_MAX,
+  I8_MIN,
+  I8_MAX,
+  I16_MIN,
+  I16_MAX,
+  I32_MIN,
+  I32_MAX,
+  I64_MIN,
+  I64_MAX,
+  I128_MIN,
+  I128_MAX,
+  validateUnsignedNumber,
+  validateSignedNumber,
+  validateUnsignedBigInt,
+  validateSignedBigInt,
+  type IntegerValidationError,
+} from "./integer-bounds.js";
 
-/** Singleton null value */
-export const Null: RelishNull = { type: "null" };
+/**
+ * Convert a validation error to a thrown Error for value constructors.
+ * @internal
+ */
+function throwValidationError(typeName: string, error: IntegerValidationError): never {
+  if (error.kind === "not_integer") {
+    throw new Error(`${typeName} value must be an integer: ${error.value}`);
+  } else {
+    throw new Error(`${typeName} value out of range: ${error.value}`);
+  }
+}
+
+/**
+ * Singleton null value.
+ *
+ * @example
+ * ```typescript
+ * import { Null, encode } from '@grounds/core';
+ *
+ * const result = encode(Null);
+ * ```
+ */
+export const Null: RelishNull = { [RELISH_BRAND]: true, type: "null" };
 
 /** Create a boolean value */
 export function Bool(value: boolean): RelishBool {
-  return { type: "bool", value };
+  return { [RELISH_BRAND]: true, type: "bool", value };
 }
 
-// Integer range constants
-const U8_MAX = 255;
-const U16_MAX = 65535;
-const U32_MAX = 4294967295;
-const U64_MAX = 18446744073709551615n;
-const U128_MAX = 340282366920938463463374607431768211455n;
-
-const I8_MIN = -128;
-const I8_MAX = 127;
-const I16_MIN = -32768;
-const I16_MAX = 32767;
-const I32_MIN = -2147483648;
-const I32_MAX = 2147483647;
-const I64_MIN = -9223372036854775808n;
-const I64_MAX = 9223372036854775807n;
-const I128_MIN = -170141183460469231731687303715884105728n;
-const I128_MAX = 170141183460469231731687303715884105727n;
-
-/** Create an unsigned 8-bit integer value */
+/**
+ * Creates an unsigned 8-bit integer Relish value.
+ *
+ * @group Value Constructors
+ *
+ * @param value - Integer in range 0-255
+ * @returns RelishU8 value
+ * @throws Error if value is not an integer or out of range
+ *
+ * @example
+ * ```typescript
+ * import { U8 } from '@grounds/core';
+ *
+ * const valid = U8(42);     // OK
+ * const edge = U8(255);     // OK (max value)
+ * const zero = U8(0);       // OK (min value)
+ *
+ * // Runtime errors:
+ * // U8(-1)    // Error: out of range
+ * // U8(256)   // Error: out of range
+ * // U8(3.14)  // Error: not an integer
+ * ```
+ */
 export function U8(value: number): RelishU8 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`U8 value must be an integer: ${value}`);
+  const error = validateUnsignedNumber(value, U8_MAX);
+  if (error) {
+    throwValidationError("U8", error);
   }
-  if (value < 0 || value > U8_MAX) {
-    throw new Error(`U8 value out of range: ${value}`);
-  }
-  return { type: "u8", value };
+  return { [RELISH_BRAND]: true, type: "u8", value };
 }
 
 /** Create an unsigned 16-bit integer value */
 export function U16(value: number): RelishU16 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`U16 value must be an integer: ${value}`);
+  const error = validateUnsignedNumber(value, U16_MAX);
+  if (error) {
+    throwValidationError("U16", error);
   }
-  if (value < 0 || value > U16_MAX) {
-    throw new Error(`U16 value out of range: ${value}`);
-  }
-  return { type: "u16", value };
+  return { [RELISH_BRAND]: true, type: "u16", value };
 }
 
 /** Create an unsigned 32-bit integer value */
 export function U32(value: number): RelishU32 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`U32 value must be an integer: ${value}`);
+  const error = validateUnsignedNumber(value, U32_MAX);
+  if (error) {
+    throwValidationError("U32", error);
   }
-  if (value < 0 || value > U32_MAX) {
-    throw new Error(`U32 value out of range: ${value}`);
-  }
-  return { type: "u32", value };
+  return { [RELISH_BRAND]: true, type: "u32", value };
 }
 
 /** Create an unsigned 64-bit integer value */
 export function U64(value: bigint): RelishU64 {
-  if (value < 0n || value > U64_MAX) {
-    throw new Error(`U64 value out of range: ${value}`);
+  const error = validateUnsignedBigInt(value, U64_MAX);
+  if (error) {
+    throwValidationError("U64", error);
   }
-  return { type: "u64", value };
+  return { [RELISH_BRAND]: true, type: "u64", value };
 }
 
 /** Create an unsigned 128-bit integer value */
 export function U128(value: bigint): RelishU128 {
-  if (value < 0n || value > U128_MAX) {
-    throw new Error(`U128 value out of range: ${value}`);
+  const error = validateUnsignedBigInt(value, U128_MAX);
+  if (error) {
+    throwValidationError("U128", error);
   }
-  return { type: "u128", value };
+  return { [RELISH_BRAND]: true, type: "u128", value };
 }
 
 /** Create a signed 8-bit integer value */
 export function I8(value: number): RelishI8 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`I8 value must be an integer: ${value}`);
+  const error = validateSignedNumber(value, I8_MIN, I8_MAX);
+  if (error) {
+    throwValidationError("I8", error);
   }
-  if (value < I8_MIN || value > I8_MAX) {
-    throw new Error(`I8 value out of range: ${value}`);
-  }
-  return { type: "i8", value };
+  return { [RELISH_BRAND]: true, type: "i8", value };
 }
 
 /** Create a signed 16-bit integer value */
 export function I16(value: number): RelishI16 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`I16 value must be an integer: ${value}`);
+  const error = validateSignedNumber(value, I16_MIN, I16_MAX);
+  if (error) {
+    throwValidationError("I16", error);
   }
-  if (value < I16_MIN || value > I16_MAX) {
-    throw new Error(`I16 value out of range: ${value}`);
-  }
-  return { type: "i16", value };
+  return { [RELISH_BRAND]: true, type: "i16", value };
 }
 
 /** Create a signed 32-bit integer value */
 export function I32(value: number): RelishI32 {
-  if (!Number.isInteger(value)) {
-    throw new Error(`I32 value must be an integer: ${value}`);
+  const error = validateSignedNumber(value, I32_MIN, I32_MAX);
+  if (error) {
+    throwValidationError("I32", error);
   }
-  if (value < I32_MIN || value > I32_MAX) {
-    throw new Error(`I32 value out of range: ${value}`);
-  }
-  return { type: "i32", value };
+  return { [RELISH_BRAND]: true, type: "i32", value };
 }
 
 /** Create a signed 64-bit integer value */
 export function I64(value: bigint): RelishI64 {
-  if (value < I64_MIN || value > I64_MAX) {
-    throw new Error(`I64 value out of range: ${value}`);
+  const error = validateSignedBigInt(value, I64_MIN, I64_MAX);
+  if (error) {
+    throwValidationError("I64", error);
   }
-  return { type: "i64", value };
+  return { [RELISH_BRAND]: true, type: "i64", value };
 }
 
 /** Create a signed 128-bit integer value */
 export function I128(value: bigint): RelishI128 {
-  if (value < I128_MIN || value > I128_MAX) {
-    throw new Error(`I128 value out of range: ${value}`);
+  const error = validateSignedBigInt(value, I128_MIN, I128_MAX);
+  if (error) {
+    throwValidationError("I128", error);
   }
-  return { type: "i128", value };
+  return { [RELISH_BRAND]: true, type: "i128", value };
 }
 
 /** Create a 32-bit floating point value */
 export function F32(value: number): RelishF32 {
-  return { type: "f32", value };
+  return { [RELISH_BRAND]: true, type: "f32", value };
 }
 
 /** Create a 64-bit floating point value */
 export function F64(value: number): RelishF64 {
-  return { type: "f64", value };
+  return { [RELISH_BRAND]: true, type: "f64", value };
 }
 
 /** Create a string value (named String_ to avoid conflict with global String) */
 export function String_(value: string): RelishString {
-  return { type: "string", value };
+  return { [RELISH_BRAND]: true, type: "string", value };
 }
 
 /**
@@ -227,7 +266,7 @@ export function Array_<T extends TypeCode>(
       );
     }
   }
-  return { type: "array", elementType, elements };
+  return { [RELISH_BRAND]: true, type: "array", elementType, elements };
 }
 
 /**
@@ -262,20 +301,20 @@ export function Map_<K extends TypeCode, V extends TypeCode>(
       );
     }
   }
-  return { type: "map", keyType, valueType, entries };
+  return { [RELISH_BRAND]: true, type: "map", keyType, valueType, entries };
 }
 
 /** Create a struct value */
 export function Struct(fields: ReadonlyMap<number, RelishValue>): RelishStruct {
-  return { type: "struct", fields };
+  return { [RELISH_BRAND]: true, type: "struct", fields };
 }
 
 /** Create an enum value */
 export function Enum(variantId: number, value: RelishValue): RelishEnum {
-  return { type: "enum", variantId, value };
+  return { [RELISH_BRAND]: true, type: "enum", variantId, value };
 }
 
 /** Create a timestamp value */
 export function Timestamp(unixSeconds: bigint): RelishTimestamp {
-  return { type: "timestamp", unixSeconds };
+  return { [RELISH_BRAND]: true, type: "timestamp", unixSeconds };
 }

--- a/packages/core/tests/encoder.test.ts
+++ b/packages/core/tests/encoder.test.ts
@@ -413,3 +413,210 @@ describe("encode maps (Rust test vectors)", () => {
     );
   });
 });
+
+describe("encoder validation (defense in depth)", () => {
+  // These tests simulate runtime bypass of branded types using 'as unknown as RelishValue'
+  // to verify encoder validation catches invalid values even when type system is bypassed.
+
+  describe("u8 range validation", () => {
+    it("rejects value above u8 max (255)", () => {
+      const invalidValue = { type: "u8", value: 300 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects negative u8 value", () => {
+      const invalidValue = { type: "u8", value: -1 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer u8 value", () => {
+      const invalidValue = { type: "u8", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("u16 range validation", () => {
+    it("rejects value above u16 max (65535)", () => {
+      const invalidValue = { type: "u16", value: 70000 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects negative u16 value", () => {
+      const invalidValue = { type: "u16", value: -1 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer u16 value", () => {
+      const invalidValue = { type: "u16", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("u32 range validation", () => {
+    it("rejects value above u32 max (4294967295)", () => {
+      const invalidValue = { type: "u32", value: 4294967296 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects negative u32 value", () => {
+      const invalidValue = { type: "u32", value: -1 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer u32 value", () => {
+      const invalidValue = { type: "u32", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("u64 range validation", () => {
+    it("rejects value above u64 max", () => {
+      const invalidValue = { type: "u64", value: 18446744073709551616n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects negative u64 value", () => {
+      const invalidValue = { type: "u64", value: -1n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+  });
+
+  describe("u128 range validation", () => {
+    it("rejects value above u128 max", () => {
+      const invalidValue = { type: "u128", value: 340282366920938463463374607431768211456n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects negative u128 value", () => {
+      const invalidValue = { type: "u128", value: -1n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+  });
+
+  describe("i8 range validation", () => {
+    it("rejects value above i8 max (127)", () => {
+      const invalidValue = { type: "i8", value: 128 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects value below i8 min (-128)", () => {
+      const invalidValue = { type: "i8", value: -129 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer i8 value", () => {
+      const invalidValue = { type: "i8", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("i16 range validation", () => {
+    it("rejects value above i16 max (32767)", () => {
+      const invalidValue = { type: "i16", value: 32768 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects value below i16 min (-32768)", () => {
+      const invalidValue = { type: "i16", value: -32769 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer i16 value", () => {
+      const invalidValue = { type: "i16", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("i32 range validation", () => {
+    it("rejects value above i32 max (2147483647)", () => {
+      const invalidValue = { type: "i32", value: 2147483648 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects value below i32 min (-2147483648)", () => {
+      const invalidValue = { type: "i32", value: -2147483649 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects non-integer i32 value", () => {
+      const invalidValue = { type: "i32", value: 3.14 } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("integer");
+    });
+  });
+
+  describe("i64 range validation", () => {
+    it("rejects value above i64 max", () => {
+      const invalidValue = { type: "i64", value: 9223372036854775808n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects value below i64 min", () => {
+      const invalidValue = { type: "i64", value: -9223372036854775809n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+  });
+
+  describe("i128 range validation", () => {
+    it("rejects value above i128 max", () => {
+      const invalidValue = { type: "i128", value: 170141183460469231731687303715884105728n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+
+    it("rejects value below i128 min", () => {
+      const invalidValue = { type: "i128", value: -170141183460469231731687303715884105729n } as unknown as RelishValue;
+      const result = encode(invalidValue);
+      expectErr(result);
+      expect(result._unsafeUnwrapErr().message).toContain("out of range");
+    });
+  });
+});

--- a/packages/core/tests/roundtrip.test.ts
+++ b/packages/core/tests/roundtrip.test.ts
@@ -255,14 +255,24 @@ describe("Roundtrip encode/decode", () => {
           const uniqueEntries = new Map(entries);
           const value = Map_(TypeCode.U32, TypeCode.String, uniqueEntries);
           const encoded = encode(value);
-          if (encoded.isErr()) return false;
+          if (encoded.isErr()) {
+            return false;
+          }
           const decoded = decode(encoded.value);
-          if (decoded.isErr()) return false;
+          if (decoded.isErr()) {
+            return false;
+          }
           const decodedMap = decoded.value;
-          if (!(decodedMap instanceof Map)) return false;
-          if (decodedMap.size !== uniqueEntries.size) return false;
+          if (!(decodedMap instanceof Map)) {
+            return false;
+          }
+          if (decodedMap.size !== uniqueEntries.size) {
+            return false;
+          }
           for (const [k, v] of uniqueEntries) {
-            if (decodedMap.get(k) !== v) return false;
+            if (decodedMap.get(k) !== v) {
+              return false;
+            }
           }
           return true;
         }

--- a/packages/core/tests/values.test.ts
+++ b/packages/core/tests/values.test.ts
@@ -27,27 +27,27 @@ import { TypeCode } from "../src/types.js";
 describe("Value constructors", () => {
   describe("Null", () => {
     it("creates null value", () => {
-      expect(Null).toEqual({ type: "null" });
+      expect(Null).toMatchObject({ type: "null" });
     });
   });
 
   describe("Bool", () => {
     it("creates true value", () => {
-      expect(Bool(true)).toEqual({ type: "bool", value: true });
+      expect(Bool(true)).toMatchObject({ type: "bool", value: true });
     });
 
     it("creates false value", () => {
-      expect(Bool(false)).toEqual({ type: "bool", value: false });
+      expect(Bool(false)).toMatchObject({ type: "bool", value: false });
     });
   });
 
   describe("unsigned integers", () => {
     it("creates U8 value", () => {
-      expect(U8(255)).toEqual({ type: "u8", value: 255 });
+      expect(U8(255)).toMatchObject({ type: "u8", value: 255 });
     });
 
     it("creates U8 with zero", () => {
-      expect(U8(0)).toEqual({ type: "u8", value: 0 });
+      expect(U8(0)).toMatchObject({ type: "u8", value: 0 });
     });
 
     it("throws on U8 overflow", () => {
@@ -63,11 +63,11 @@ describe("Value constructors", () => {
     });
 
     it("creates U16 value", () => {
-      expect(U16(65535)).toEqual({ type: "u16", value: 65535 });
+      expect(U16(65535)).toMatchObject({ type: "u16", value: 65535 });
     });
 
     it("creates U16 with zero", () => {
-      expect(U16(0)).toEqual({ type: "u16", value: 0 });
+      expect(U16(0)).toMatchObject({ type: "u16", value: 0 });
     });
 
     it("throws on U16 overflow", () => {
@@ -83,11 +83,11 @@ describe("Value constructors", () => {
     });
 
     it("creates U32 value", () => {
-      expect(U32(4294967295)).toEqual({ type: "u32", value: 4294967295 });
+      expect(U32(4294967295)).toMatchObject({ type: "u32", value: 4294967295 });
     });
 
     it("creates U32 with zero", () => {
-      expect(U32(0)).toEqual({ type: "u32", value: 0 });
+      expect(U32(0)).toMatchObject({ type: "u32", value: 0 });
     });
 
     it("throws on U32 overflow", () => {
@@ -103,14 +103,14 @@ describe("Value constructors", () => {
     });
 
     it("creates U64 value", () => {
-      expect(U64(18446744073709551615n)).toEqual({
+      expect(U64(18446744073709551615n)).toMatchObject({
         type: "u64",
         value: 18446744073709551615n,
       });
     });
 
     it("creates U64 with zero", () => {
-      expect(U64(0n)).toEqual({ type: "u64", value: 0n });
+      expect(U64(0n)).toMatchObject({ type: "u64", value: 0n });
     });
 
     it("throws on U64 overflow", () => {
@@ -123,11 +123,11 @@ describe("Value constructors", () => {
 
     it("creates U128 value", () => {
       const max = 340282366920938463463374607431768211455n;
-      expect(U128(max)).toEqual({ type: "u128", value: max });
+      expect(U128(max)).toMatchObject({ type: "u128", value: max });
     });
 
     it("creates U128 with zero", () => {
-      expect(U128(0n)).toEqual({ type: "u128", value: 0n });
+      expect(U128(0n)).toMatchObject({ type: "u128", value: 0n });
     });
 
     it("throws on U128 overflow", () => {
@@ -142,15 +142,15 @@ describe("Value constructors", () => {
 
   describe("signed integers", () => {
     it("creates I8 value at min", () => {
-      expect(I8(-128)).toEqual({ type: "i8", value: -128 });
+      expect(I8(-128)).toMatchObject({ type: "i8", value: -128 });
     });
 
     it("creates I8 value at max", () => {
-      expect(I8(127)).toEqual({ type: "i8", value: 127 });
+      expect(I8(127)).toMatchObject({ type: "i8", value: 127 });
     });
 
     it("creates I8 with zero", () => {
-      expect(I8(0)).toEqual({ type: "i8", value: 0 });
+      expect(I8(0)).toMatchObject({ type: "i8", value: 0 });
     });
 
     it("throws on I8 overflow", () => {
@@ -166,15 +166,15 @@ describe("Value constructors", () => {
     });
 
     it("creates I16 value at min", () => {
-      expect(I16(-32768)).toEqual({ type: "i16", value: -32768 });
+      expect(I16(-32768)).toMatchObject({ type: "i16", value: -32768 });
     });
 
     it("creates I16 value at max", () => {
-      expect(I16(32767)).toEqual({ type: "i16", value: 32767 });
+      expect(I16(32767)).toMatchObject({ type: "i16", value: 32767 });
     });
 
     it("creates I16 with zero", () => {
-      expect(I16(0)).toEqual({ type: "i16", value: 0 });
+      expect(I16(0)).toMatchObject({ type: "i16", value: 0 });
     });
 
     it("throws on I16 overflow", () => {
@@ -190,15 +190,15 @@ describe("Value constructors", () => {
     });
 
     it("creates I32 value at min", () => {
-      expect(I32(-2147483648)).toEqual({ type: "i32", value: -2147483648 });
+      expect(I32(-2147483648)).toMatchObject({ type: "i32", value: -2147483648 });
     });
 
     it("creates I32 value at max", () => {
-      expect(I32(2147483647)).toEqual({ type: "i32", value: 2147483647 });
+      expect(I32(2147483647)).toMatchObject({ type: "i32", value: 2147483647 });
     });
 
     it("creates I32 with zero", () => {
-      expect(I32(0)).toEqual({ type: "i32", value: 0 });
+      expect(I32(0)).toMatchObject({ type: "i32", value: 0 });
     });
 
     it("throws on I32 overflow", () => {
@@ -214,21 +214,21 @@ describe("Value constructors", () => {
     });
 
     it("creates I64 value at min", () => {
-      expect(I64(-9223372036854775808n)).toEqual({
+      expect(I64(-9223372036854775808n)).toMatchObject({
         type: "i64",
         value: -9223372036854775808n,
       });
     });
 
     it("creates I64 value at max", () => {
-      expect(I64(9223372036854775807n)).toEqual({
+      expect(I64(9223372036854775807n)).toMatchObject({
         type: "i64",
         value: 9223372036854775807n,
       });
     });
 
     it("creates I64 with zero", () => {
-      expect(I64(0n)).toEqual({ type: "i64", value: 0n });
+      expect(I64(0n)).toMatchObject({ type: "i64", value: 0n });
     });
 
     it("throws on I64 overflow", () => {
@@ -241,16 +241,16 @@ describe("Value constructors", () => {
 
     it("creates I128 value at min", () => {
       const min = -170141183460469231731687303715884105728n;
-      expect(I128(min)).toEqual({ type: "i128", value: min });
+      expect(I128(min)).toMatchObject({ type: "i128", value: min });
     });
 
     it("creates I128 value at max", () => {
       const max = 170141183460469231731687303715884105727n;
-      expect(I128(max)).toEqual({ type: "i128", value: max });
+      expect(I128(max)).toMatchObject({ type: "i128", value: max });
     });
 
     it("creates I128 with zero", () => {
-      expect(I128(0n)).toEqual({ type: "i128", value: 0n });
+      expect(I128(0n)).toMatchObject({ type: "i128", value: 0n });
     });
 
     it("throws on I128 overflow", () => {
@@ -266,11 +266,11 @@ describe("Value constructors", () => {
 
   describe("floating point", () => {
     it("creates F32 value", () => {
-      expect(F32(3.14)).toEqual({ type: "f32", value: 3.14 });
+      expect(F32(3.14)).toMatchObject({ type: "f32", value: 3.14 });
     });
 
     it("creates F64 value", () => {
-      expect(F64(3.141592653589793)).toEqual({
+      expect(F64(3.141592653589793)).toMatchObject({
         type: "f64",
         value: 3.141592653589793,
       });
@@ -279,18 +279,18 @@ describe("Value constructors", () => {
 
   describe("String_", () => {
     it("creates string value", () => {
-      expect(String_("hello")).toEqual({ type: "string", value: "hello" });
+      expect(String_("hello")).toMatchObject({ type: "string", value: "hello" });
     });
 
     it("creates empty string value", () => {
-      expect(String_("")).toEqual({ type: "string", value: "" });
+      expect(String_("")).toMatchObject({ type: "string", value: "" });
     });
   });
 
   describe("Array_", () => {
     it("creates array of u32 with raw number elements", () => {
       // Elements are raw JS values, not wrapped RelishValue
-      expect(Array_(TypeCode.U32, [1, 2, 3])).toEqual({
+      expect(Array_(TypeCode.U32, [1, 2, 3])).toMatchObject({
         type: "array",
         elementType: TypeCode.U32,
         elements: [1, 2, 3],
@@ -298,7 +298,7 @@ describe("Value constructors", () => {
     });
 
     it("creates array of strings with raw string elements", () => {
-      expect(Array_(TypeCode.String, ["hello", "world"])).toEqual({
+      expect(Array_(TypeCode.String, ["hello", "world"])).toMatchObject({
         type: "array",
         elementType: TypeCode.String,
         elements: ["hello", "world"],
@@ -306,7 +306,7 @@ describe("Value constructors", () => {
     });
 
     it("creates array of bigint types with raw bigint elements", () => {
-      expect(Array_(TypeCode.U64, [1n, 2n, 3n])).toEqual({
+      expect(Array_(TypeCode.U64, [1n, 2n, 3n])).toMatchObject({
         type: "array",
         elementType: TypeCode.U64,
         elements: [1n, 2n, 3n],
@@ -314,7 +314,7 @@ describe("Value constructors", () => {
     });
 
     it("creates empty array", () => {
-      expect(Array_(TypeCode.String, [])).toEqual({
+      expect(Array_(TypeCode.String, [])).toMatchObject({
         type: "array",
         elementType: TypeCode.String,
         elements: [],
@@ -325,7 +325,7 @@ describe("Value constructors", () => {
       // Composite element types hold RelishValue
       const inner1 = Array_(TypeCode.U8, [1, 2]);
       const inner2 = Array_(TypeCode.U8, [3, 4]);
-      expect(Array_(TypeCode.Array, [inner1, inner2])).toEqual({
+      expect(Array_(TypeCode.Array, [inner1, inner2])).toMatchObject({
         type: "array",
         elementType: TypeCode.Array,
         elements: [inner1, inner2],
@@ -410,7 +410,7 @@ describe("Value constructors", () => {
         [1, String_("name")],
         [2, U32(42)],
       ]);
-      expect(Struct(fields)).toEqual({
+      expect(Struct(fields)).toMatchObject({
         type: "struct",
         fields,
       });
@@ -419,7 +419,7 @@ describe("Value constructors", () => {
 
   describe("Enum", () => {
     it("creates enum value", () => {
-      expect(Enum(1, String_("data"))).toEqual({
+      expect(Enum(1, String_("data"))).toMatchObject({
         type: "enum",
         variantId: 1,
         value: { type: "string", value: "data" },
@@ -429,7 +429,7 @@ describe("Value constructors", () => {
 
   describe("Timestamp", () => {
     it("creates timestamp value", () => {
-      expect(Timestamp(1704067200n)).toEqual({
+      expect(Timestamp(1704067200n)).toMatchObject({
         type: "timestamp",
         unixSeconds: 1704067200n,
       });

--- a/packages/stream/tests/schema-streams.test.ts
+++ b/packages/stream/tests/schema-streams.test.ts
@@ -31,7 +31,9 @@ describe("createSchemaEncoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       chunks.push(value);
     }
 
@@ -55,7 +57,9 @@ describe("createSchemaEncoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       chunks.push(value);
     }
 
@@ -105,7 +109,9 @@ describe("createSchemaEncoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       chunks.push(value);
     }
 
@@ -145,7 +151,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       users.push(value);
     }
 
@@ -171,7 +179,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       values.push(value);
     }
 
@@ -244,7 +254,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       users.push(value);
     }
 
@@ -282,7 +294,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       decodedValues.push(value);
     }
 
@@ -314,7 +328,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       values.push(value);
     }
 
@@ -341,7 +357,9 @@ describe("createSchemaDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       values.push(value);
     }
 
@@ -381,7 +399,9 @@ describe("roundtrip: encoder -> decoder", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       result.push(value);
     }
 

--- a/packages/stream/tests/web-streams.test.ts
+++ b/packages/stream/tests/web-streams.test.ts
@@ -22,7 +22,9 @@ describe("createEncoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       chunks.push(value);
     }
 
@@ -46,7 +48,9 @@ describe("createDecoderStream", () => {
 
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       values.push(value);
     }
 


### PR DESCRIPTION
## Summary

- **Branded types**: All `RelishValue` types now include a `RELISH_BRAND` symbol that prevents direct object literal construction - values must be created through constructor functions (`U8()`, `String_()`, etc.)
- **Encoder validation**: Defense-in-depth validation catches invalid integer values at encoding time, returning `EncodeError` for out-of-range or non-integer values
- **Consolidated validation**: Extracted shared integer bounds and validation functions to `integer-bounds.ts`, eliminating duplication between `values.ts` and `encoder.ts`

## Test plan

- [x] All 382 existing tests pass
- [x] 26 new encoder validation tests verify defense-in-depth catches invalid values
- [x] TypeScript compilation succeeds with no errors
- [x] Pre-push hook runs full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)