### PR TITLE
fix(release): exclude private test-utils package from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@grounds/examples"]
+  "ignore": ["@grounds/examples", "@grounds/test-utils"]
 }


### PR DESCRIPTION
## Summary

- Add `@grounds/test-utils` to the changeset ignore list
- Package is marked `private: true` and should not generate version bumps

Fixes the spurious version PR #54 that was opened for test-utils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)